### PR TITLE
truncated summary included on talks index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+src/.DS_Store
+node_modules/
+
+.DS_Store

--- a/src/components/talks_index.js
+++ b/src/components/talks_index.js
@@ -14,8 +14,13 @@ class TalksIndex extends Component {
       return (
         <li className="list-group-item" key={talk.id}>
           <Link to={`/talks/${talk.id}`}>
-            {talk.title}
+          <div className="title">
+            <strong>{talk.title}</strong>
+          </div> {/*title*/}
           </Link>
+          <div className="description">
+            {talk.description}
+          </div> {/*description*/}
         </li>
       );
     });

--- a/style/style.css
+++ b/style/style.css
@@ -11,3 +11,13 @@ div.navbar {
   background-color: #eee;
   margin:10px;
 }
+
+.title {
+  font-size: 22px;
+}
+
+.description {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}


### PR DESCRIPTION
This will add a truncated summary to the talks index as described in FE issue 1: https://github.com/rubyjax/RubyJaxFE/issues/1

Note that we will be replacing the date with the length of the talk which will be included in a later increment.